### PR TITLE
feat: split out functionality into multiple roles

### DIFF
--- a/deploy_devspaces.yml
+++ b/deploy_devspaces.yml
@@ -2,7 +2,20 @@
 - name: Deploy devspaces and samples
   hosts: localhost
   gather_facts: false
+  vars:
+    agp_devspaces_namespace: devspaces-two
+  #   agp_featuregate_enabled_features:
+  #     - ProcMountType
+  #     - UserNamespacesSupport
+  #     - UserNamespacesPodSecurityStandards
+  #     - Example
+  #     - AutomatedEtcdBackup
   tasks:
+    - name: Playbook deploy_devspaces | Include role agp_featuregate
+      ansible.builtin.include_role:
+        name: jeffcpullen.agnosticp.agp_featuregate
+      vars:
+        ACTION: 'create'
     - name: Playbook deploy_devspaces | Include role agp_devspaces
       ansible.builtin.include_role:
         name: jeffcpullen.agnosticp.agp_devspaces

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,7 @@
 
 namespace: "jeffcpullen"
 name: "agnosticp"
-version: 1.0.2
+version: 1.0.3
 readme: README.md
 authors:
   - Jeff Pullen <redhat.com>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 # TO-DO: add python packages that are required for this collection
 kubernetes
+jmespath

--- a/roles/agp_devspaces/defaults/main.yml
+++ b/roles/agp_devspaces/defaults/main.yml
@@ -4,9 +4,9 @@ agp_devspaces_become_override: false
 agp_devspaces_state: present
 agp_devspaces_tech_preview_user_namespaces: true
 agp_devspaces_namespace: 'devspaces'
-agp_devspaces_operator_group_create: true
-agp_devspaces_operator_group_name: 'devspaces-og'
-agp_devspaces_operator_group_spec: {}
+# agp_devspaces_operator_group_create: true
+# agp_devspaces_operator_group_name: 'devspaces-og'
+# agp_devspaces_operator_group_spec: {}
 
 ## Operator Catalog Settings
 agp_devspaces_operator_catalog_create: true
@@ -25,7 +25,7 @@ agp_devspaces_operator_devspaces_labels:
   olm.managed: 'true'
   operators.coreos.com/devspaces.devspaces: ''
 agp_devspaces_operator_devspaces_channel: stable
-agp_devspaces_operator_devspaces_install_plan: Automatic
+agp_devspaces_operator_devspaces_install_plan_automatic: true
 agp_devspaces_operator_devspaces_operator_name: devspaces
 agp_devspaces_operator_devspaces_source: 'redhat-operators'
 agp_devspaces_operator_devspaces_source_namespace: 'openshift-marketplace'
@@ -38,7 +38,7 @@ agp_devspaces_operator_devworkspace_labels:
   olm.managed: 'true'
   operators.coreos.com/devworkspace-operator.devspaces: ''
 agp_devspaces_operator_devworkspace_channel: fast
-agp_devspaces_operator_devworkspace_install_plan: 'Automatic'
+agp_devspaces_operator_devworkspace_install_plan_automatic: true
 agp_devspaces_operator_devworkspace_operator_name: 'devworkspace-operator'
 agp_devspaces_operator_devworkspace_source: 'redhat-operators'
 agp_devspaces_operator_devworkspace_source_namespace: 'openshift-marketplace'

--- a/roles/agp_devspaces/tasks/install_operator.yml
+++ b/roles/agp_devspaces/tasks/install_operator.yml
@@ -1,0 +1,160 @@
+---
+- name: Check that operator name has been provided
+  assert:
+    that:
+      - install_operator_name | default("") | length > 0
+    fail_msg: install_operator_name must be set.
+
+- name: "{{ install_operator_name }} - Set up for Namespace other than 'openshift-operators'"
+  when: install_operator_namespace is not match("openshift-operators")
+  block:
+    - name: "{{ install_operator_name }} - Ensure Namespace exists"
+      kubernetes.core.k8s:
+        state: present
+        api_version: v1
+        kind: Namespace
+        name: "{{ install_operator_namespace }}"
+    - name: "{{ install_operator_name }} - Ensure OperatorGroup exists"
+      kubernetes.core.k8s:
+        state: present
+        definition: "{{ lookup('template', 'operatorgroup.yaml.j2' ) | from_yaml }}"
+
+- name: "{{ install_operator_name }} - Create CatalogSource for use with catalog snapshot"
+  when: install_operator_catalogsource_setup | bool
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'catalogsource.yaml.j2' ) | from_yaml }}"
+
+- name: "{{ install_operator_name }} - Set subscription channel to provided channel"
+  when: install_operator_channel | default("") | length > 0
+  set_fact:
+    __install_operator_channel: "{{ install_operator_channel }}"
+
+- name: "{{ install_operator_name }} - Determine channel for the operator if no channel specified"
+  when: install_operator_channel | default("") | length == 0
+  block:
+    - name: Get cluster version
+      kubernetes.core.k8s_info:
+        api_version: config.openshift.io/v1
+        kind: ClusterVersion
+        name: version
+      register: r_cluster_version
+    - name: "{{ install_operator_name }} - Get PackageManifest for the operator"
+      kubernetes.core.k8s_info:
+        api_version: packages.operators.coreos.com/v1
+        kind: PackageManifest
+        name: "{{ install_operator_packagemanifest_name }}"
+        namespace: "{{ install_operator_catalogsource_namespace }}"
+      register: r_packagemanifest
+
+    # Set channel to the one matching the deployed cluster version.
+    # If no matching channel available set to defaultChannel from the package manifest.
+    - name: "{{ install_operator_name }} - Set operator channel"
+      set_fact:
+        __install_operator_channel: "{{ t_channel | regex_replace(' ') }}"
+      vars:
+        t_cluster_version: >-
+          {{ r_cluster_version.resources[0].spec.channel | regex_replace('.*-(\d+\.\d+)', '\1') }}
+        t_version_match_query: "[?name=='{{ t_cluster_version }}']|[0].name"
+        t_version_match_channel: >-
+          {{ r_packagemanifest.resources[0].status.channels | json_query(t_version_match_query) }}
+        t_channel: >-
+          {{ t_version_match_channel | default(r_packagemanifest.resources[0].status.defaultChannel, true) }}
+
+- name: "{{ install_operator_name }} - Print operator channel to be installed"
+  ansible.builtin.debug:
+    msg: "Operator channel to be installed: {{ __install_operator_channel }}"
+
+- name: "{{ install_operator_name }} - Create operator subscription"
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'subscription.yaml.j2' ) | from_yaml }}"
+
+- name: "{{ install_operator_name }} - Wait until InstallPlan is created"
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    namespace: "{{ install_operator_namespace }}"
+  register: r_install_plans
+  retries: 30
+  delay: 10
+  until:
+    - r_install_plans.resources | default([]) | length > 0
+
+# - name: Debug install Install
+#   ansible.builtin.debug:
+#     var: "{{ item }}"
+#   loop: "{{ r_install_plans['resources'] }}"
+
+# - name: Search the list
+#   ansible.builtin.debug:
+#     msg: "{{ r_install_plans['resources'] | select('search', install_operator_packagemanifest_name) }}"
+
+# - name: "{{ install_operator_name }} - Set InstallPlan name"
+#   vars:
+#     __agp_devspaces_plan_query: >-
+#       [?starts_with(spec.clusterServiceVersionNames[2], '{{ install_operator_csv_nameprefix }}' )].metadata.name|[0]
+#   ansible.builtin.set_fact:
+#     install_operator_install_plan_name: "{{ r_install_plans.resources | to_json | from_json | json_query(__agp_devspaces_plan_query) }}"
+
+
+- name: Select install plans
+  when: __agp_devspaces_install_plan_loop['spec']['clusterServiceVersionNames'][0] == install_operator_starting_csv
+  ansible.builtin.set_fact:
+    __agp_devspaces_install_plan_info_name: "{{ __agp_devspaces_install_plan_loop['metadata']['name'] }}"
+    __agp_devspaces_install_plan_info_csv: "{{ __agp_devspaces_install_plan_loop['spec']['clusterServiceVersionNames'][0] }}"
+    __agp_devspaces_install_plan_info_resource: "{{ __agp_devspaces_install_plan_loop }}"
+  loop: "{{ r_install_plans.resources }}"
+  loop_control:
+    loop_var: __agp_devspaces_install_plan_loop
+  until: __agp_devspaces_install_plan_info_name is defined
+
+- name: Debug install plan name
+  ansible.builtin.debug:
+    var: __agp_devspaces_install_plan_info_name
+
+- name: Debug install plan csv
+  ansible.builtin.debug:
+    var: __agp_devspaces_install_plan_info_csv
+
+- name: "{{ install_operator_name }} - Approve InstallPlan if necessary"
+  when: __agp_devspaces_install_plan_info_resource.status.phase is match("RequiresApproval")
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup( 'template', 'installplan.yaml.j2' ) }}"
+
+- name: "{{ install_operator_name }} - Get Installed CSV"
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: "{{ install_operator_name }}"
+    namespace: "{{ install_operator_namespace }}"
+  register: r_subscription
+  retries: 30
+  delay: 5
+  until:
+    - __agp_devspaces_install_plan_info_csv is defined
+    - __agp_devspaces_install_plan_info_csv | length > 0
+
+- name: debug subscription
+  ansible.builtin.debug:
+    var: r_subscription
+
+- name: Pause for a few seconds
+  ansible.builtin.pause:
+    seconds: 5
+
+- name: "{{ install_operator_name }} - Wait until CSV is installed"
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ r_subscription.resources[0].status.currentCSV }}"
+    namespace: "{{ install_operator_namespace }}"
+  register: r_csv
+  retries: 30
+  delay: 30
+  until:
+    - r_csv.resources[0].status.phase is defined
+    - r_csv.resources[0].status.phase | length > 0
+    - r_csv.resources[0].status.phase == "Succeeded"
+  ignore_errors: "{{ install_operator_install_csv_ignore_error }}"

--- a/roles/agp_devspaces/tasks/pre_workload.yml
+++ b/roles/agp_devspaces/tasks/pre_workload.yml
@@ -2,32 +2,32 @@
 # Implement your Pre Workload deployment tasks here
 # -------------------------------------------------
 
-- name: Role agp_devspaces | Task pre_workload | Create DevSpaces namespace
-  kubernetes.core.k8s:
-    state: "{{ agp_devspaces_state }}"
-    definition:
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: "{{ agp_devspaces_operator_devspaces_namespace }}"
+# - name: Role agp_devspaces | Task pre_workload | Create DevSpaces namespace
+#   kubernetes.core.k8s:
+#     state: "{{ agp_devspaces_state }}"
+#     definition:
+#       apiVersion: v1
+#       kind: Namespace
+#       metadata:
+#         name: "{{ agp_devspaces_operator_devspaces_namespace }}"
 
-- name: Role agp_devspaces | Task pre_workload | Create operator catalog
-  when: agp_devspaces_operator_catalog_create
-  kubernetes.core.k8s:
-    state: "{{ agp_devspaces_state }}"
-    definition:
-      apiVersion: operators.coreos.com/v1alpha1
-      kind: CatalogSource
-      metadata:
-        name: "{{ agp_devspaces_operator_catalog_name }}"
-        namespace: "{{ agp_devspaces_operator_catalog_namespace }}"
-      spec:
-        spec:
-        displayName: "{{ agp_devspaces_operator_catalog_display_name }}"
-        image: "{{ agp_devspaces_operator_catalog_image }}:{{ agp_devspaces_operator_catalog_image_tag }}"
-        publisher: "{{ agp_devspaces_operator_catalog_publisher }}"
-        sourceType: "{{ agp_devspaces_operator_catalog_source_type }}"
-    wait: true
+# - name: Role agp_devspaces | Task pre_workload | Create operator catalog
+#   when: agp_devspaces_operator_catalog_create
+#   kubernetes.core.k8s:
+#     state: "{{ agp_devspaces_state }}"
+#     definition:
+#       apiVersion: operators.coreos.com/v1alpha1
+#       kind: CatalogSource
+#       metadata:
+#         name: "{{ agp_devspaces_operator_catalog_name }}"
+#         namespace: "{{ agp_devspaces_operator_catalog_namespace }}"
+#       spec:
+#         spec:
+#         displayName: "{{ agp_devspaces_operator_catalog_display_name }}"
+#         image: "{{ agp_devspaces_operator_catalog_image }}:{{ agp_devspaces_operator_catalog_image_tag }}"
+#         publisher: "{{ agp_devspaces_operator_catalog_publisher }}"
+#         sourceType: "{{ agp_devspaces_operator_catalog_source_type }}"
+#     wait: true
     # wait_condition:
     #   type: connectionState
     #   status: true

--- a/roles/agp_devspaces/tasks/workload.yml
+++ b/roles/agp_devspaces/tasks/workload.yml
@@ -1,87 +1,143 @@
 ---
 
-- name: Role agp_devspaces | Task workload | Enable tech preview features
-  when: agp_devspaces_tech_preview_user_namespaces
-  kubernetes.core.k8s:
-    state: patched
-    definition:
-      apiVersion: config.openshift.io/v1
-      kind: FeatureGate
-      metadata:
-        name: cluster
-      spec:
-        featureSet: CustomNoUpgrade
-        customNoUpgrade:
-          enabled:
-            - ProcMountType
-            - UserNamespacesSupport
-            - UserNamespacesPodSecurityStandards
 
-- name: Role agp_devspaces | Task workload | Create Devspaces OperatorGroup
-  when: agp_devspaces_operator_group_create
-  kubernetes.core.k8s:
-    state: "{{ agp_devspaces_state }}"
-    definition:
-      apiVersion: operators.coreos.com/v1
-      kind: OperatorGroup
-      metadata:
-        name: "{{ agp_devspaces_operator_group_name }}"
-        namespace: "{{ agp_devspaces_operator_devspaces_namespace }}"
-      spec: "{{ agp_devspaces_operator_group_spec }}"
+
+- name: Role agp_devspaces | Task workload | Install DevWorkspace Operator
+  ansible.builtin.include_tasks: ./install_operator.yml
+  vars:
+    install_operator_action: install
+    install_operator_name: "{{ agp_devspaces_operator_devworkspace_name }}"
+    install_operator_namespace: "{{ agp_devspaces_operator_devworkspace_namespace }}"
+    install_operator_catalog: "{{ agp_devspaces_operator_catalog_name }}"
+    install_operator_channel: "{{ agp_devspaces_operator_devworkspace_channel }}"
+    install_operator_automatic_install_plan_approval: "{{ agp_devspaces_operator_devworkspace_install_plan_automatic | default(true) }}" # yamllint disable-line rule:line-length
+    install_operator_starting_csv: "{{ agp_devspaces_operator_devworkspace_starting_csv }}"
+    install_operator_packagemanifest_name: "{{ agp_devspaces_operator_devworkspace_operator_name }}"
+    # install_operator_manage_namespaces:
+    #   - "{{ agp_devspaces_namespace }}"
+    install_operator_catalogsource_setup: "{{ agp_devspaces_operator_catalog_create }}"
+    install_operator_catalogsource_name: "{{ agp_devspaces_operator_catalog_name | default('') }}"
+    install_operator_catalogsource_image: "{{ agp_devspaces_operator_catalog_image | default('') }}"
+    install_operator_catalogsource_image_tag: "{{ agp_devspaces_operator_catalog_image_tag | default('') }}"
+    install_operator_catalogsource_namespace: "{{ agp_devspaces_operator_catalog_namespace }}"
+    install_operator_csv_nameprefix: "{{ agp_devspaces_operator_devworkspace_operator_name }}"
+    install_operator_install_csv_ignore_error: false
+    install_operator_catalogsource_pullsecrets: []
+
+# TODO - better install process
+- name: Role agp_devspaces | Task workload | Install DevSpaces Operator
+  ansible.builtin.include_tasks: ./install_operator.yml
+  vars:
+    install_operator_action: install
+    install_operator_name: "{{ agp_devspaces_operator_devspaces_name }}"
+    install_operator_namespace: "{{ agp_devspaces_namespace }}"
+    install_operator_catalog: "{{ agp_devspaces_operator_catalog_name }}"
+    install_operator_channel: "{{ agp_devspaces_operator_devspaces_channel }}"
+    install_operator_automatic_install_plan_approval: "{{ agp_devspaces_operator_devspaces_install_plan_automatic | default(true) }}" # yamllint disable-line rule:line-length
+    install_operator_starting_csv: "{{ agp_devspaces_operator_devspaces_starting_csv }}"
+    install_operator_packagemanifest_name: "{{ agp_devspaces_operator_devspaces_operator_name }}"
+    # install_operator_manage_namespaces:
+    #   - "{{ agp_devspaces_namespace }}"
+    install_operator_catalogsource_setup: "{{ agp_devspaces_operator_catalog_create }}"
+    install_operator_catalogsource_name: "{{ agp_devspaces_operator_catalog_name | default('') }}"
+    install_operator_catalogsource_image: "{{ agp_devspaces_operator_catalog_image | default('') }}"
+    install_operator_catalogsource_image_tag: "{{ agp_devspaces_operator_catalog_image_tag | default('') }}"
+    install_operator_catalogsource_namespace: "{{ agp_devspaces_operator_catalog_namespace }}"
+    install_operator_csv_nameprefix: "{{ agp_devspaces_operator_devspaces_operator_name }}"
+    install_operator_install_csv_ignore_error: false
+    install_operator_catalogsource_pullsecrets: []
+
+# - name: Role agp_devspaces | Task workload | Create Devspaces OperatorGroup
+#   when: agp_devspaces_operator_group_create
+#   kubernetes.core.k8s:
+#     state: "{{ agp_devspaces_state }}"
+#     definition:
+#       apiVersion: operators.coreos.com/v1
+#       kind: OperatorGroup
+#       metadata:
+#         name: "{{ agp_devspaces_operator_group_name }}"
+#         namespace: "{{ agp_devspaces_operator_devspaces_namespace }}"
+#       spec: "{{ agp_devspaces_operator_group_spec }}"
 
 - name: Role agp_devspaces | Task workload | Create custom SCC nested-podman-scc
   kubernetes.core.k8s:
     state: "{{ agp_devspaces_state }}"
     definition: "{{ agp_devspaces_custom_nested_podman_scc }}"
 
-- name: Role agp_devspaces | Task workload | Install OCP Devworkspace Operator
-  kubernetes.core.k8s:
-    state: "{{ agp_devspaces_state }}"
-    definition:
-      apiVersion: operators.coreos.com/v1alpha1
-      kind: Subscription
-      metadata:
-        name: "{{ agp_devspaces_operator_devworkspace_name }}"
-        namespace: "{{ agp_devspaces_operator_devworkspace_namespace }}"
-        labels: "{{ agp_devspaces_operator_devworkspace_labels }}"
-      spec:
-        channel: "{{ agp_devspaces_operator_devworkspace_channel }}"
-        installPlanApproval: "{{ agp_devspaces_operator_devworkspace_install_plan }}"
-        name: "{{ agp_devspaces_operator_devworkspace_operator_name }}"
-        source: "{{ agp_devspaces_operator_devworkspace_source }}"
-        sourceNamespace: "{{ agp_devspaces_operator_devworkspace_source_namespace }}"
-        startingCSV: "{{ agp_devspaces_operator_devworkspace_starting_csv }}"
+# - name: Role agp_devspaces | Task workload | Install OCP Devworkspace Operator
+#   kubernetes.core.k8s:
+#     state: "{{ agp_devspaces_state }}"
+#     definition:
+#       apiVersion: operators.coreos.com/v1alpha1
+#       kind: Subscription
+#       metadata:
+#         name: "{{ agp_devspaces_operator_devworkspace_name }}"
+#         namespace: "{{ agp_devspaces_operator_devworkspace_namespace }}"
+#         labels: "{{ agp_devspaces_operator_devworkspace_labels }}"
+#       spec:
+#         channel: "{{ agp_devspaces_operator_devworkspace_channel }}"
+#         installPlanApproval: "{{ agp_devspaces_operator_devworkspace_install_plan }}"
+#         name: "{{ agp_devspaces_operator_devworkspace_operator_name }}"
+#         source: "{{ agp_devspaces_operator_devworkspace_source }}"
+#         sourceNamespace: "{{ agp_devspaces_operator_devworkspace_source_namespace }}"
+#         startingCSV: "{{ agp_devspaces_operator_devworkspace_starting_csv }}"
 
-- name: Role agp_devspaces | Task workload | Install OCP DevSpaces Subscription
-  kubernetes.core.k8s:
-    state: "{{ agp_devspaces_state }}"
-    definition:
-      apiVersion: operators.coreos.com/v1alpha1
-      kind: Subscription
-      metadata:
-        name: "{{ agp_devspaces_operator_devspaces_name }}"
-        namespace: "{{ agp_devspaces_operator_devspaces_namespace }}"
-        labels: "{{ agp_devspaces_operator_devspaces_labels }}"
-      spec:
-        channel: "{{ agp_devspaces_operator_devspaces_channel }}"
-        installPlanApproval: "{{ agp_devspaces_operator_devspaces_install_plan }}"
-        name: "{{ agp_devspaces_operator_devspaces_operator_name }}"
-        source: "{{ agp_devspaces_operator_devspaces_source }}"
-        sourceNamespace: "{{ agp_devspaces_operator_devspaces_source_namespace }}"
-        startingCSV: "{{ agp_devspaces_operator_devspaces_starting_csv }}"
+# - name: Role agp_devspaces | Task workload | Install OCP DevSpaces Subscription
+#   kubernetes.core.k8s:
+#     state: "{{ agp_devspaces_state }}"
+#     definition:
+#       apiVersion: operators.coreos.com/v1alpha1
+#       kind: Subscription
+#       metadata:
+#         name: "{{ agp_devspaces_operator_devspaces_name }}"
+#         namespace: "{{ agp_devspaces_operator_devspaces_namespace }}"
+#         labels: "{{ agp_devspaces_operator_devspaces_labels }}"
+#       spec:
+#         channel: "{{ agp_devspaces_operator_devspaces_channel }}"
+#         installPlanApproval: "{{ agp_devspaces_operator_devspaces_install_plan_automatic }}"
+#         name: "{{ agp_devspaces_operator_devspaces_operator_name }}"
+#         source: "{{ agp_devspaces_operator_devspaces_source }}"
+#         sourceNamespace: "{{ agp_devspaces_operator_devspaces_source_namespace }}"
+#         startingCSV: "{{ agp_devspaces_operator_devspaces_starting_csv }}"
 
-- name: Role agp_devspaces | Task workload | Create CheCluster
-  kubernetes.core.k8s:
-    state: "{{ agp_devspaces_state }}"
-    definition:
-      apiVersion: org.eclipse.che/v2
-      kind: CheCluster
-      metadata:
-        name: devspaces
-        namespace: "{{ agp_devspaces_namespace }}"
-      spec: "{{ agp_devspaces_che_cluster_spec }}"
-  retries: 30
-  delay: 30
+# - name: Role agp_devspaces | Task workload | Pause for 5 minutes to allow Operators to install
+#   ansible.builtin.pause:
+#     minutes: 5
+
+- name: Role agp_devspaces | Task workload | Install CheCluster
+  block:
+
+    - name: Role agp_devspaces | Task workload | Create CheCluster
+      kubernetes.core.k8s:
+        state: "{{ agp_devspaces_state }}"
+        definition:
+          apiVersion: org.eclipse.che/v2
+          kind: CheCluster
+          metadata:
+            name: devspaces
+            namespace: "{{ agp_devspaces_namespace }}"
+          spec: "{{ agp_devspaces_che_cluster_spec }}"
+      retries: 30
+      delay: 30
+
+  rescue:
+
+    - name: Role agp_devspaces | Task workload | Pause for 5 additional minutes to allow Operators to install
+      ansible.builtin.pause:
+        minutes: 5
+
+    - name: Role agp_devspaces | Task workload | Create CheCluster
+      kubernetes.core.k8s:
+        state: "{{ agp_devspaces_state }}"
+        definition:
+          apiVersion: org.eclipse.che/v2
+          kind: CheCluster
+          metadata:
+            name: devspaces
+            namespace: "{{ agp_devspaces_namespace }}"
+          spec: "{{ agp_devspaces_che_cluster_spec }}"
+      retries: 30
+      delay: 30
 
 - name: Role agp_devspaces | task workload | Deploy default workspace configurations
   when: agp_devspaces_default_workspace_config

--- a/roles/agp_devspaces/templates/catalogsource.yaml.j2
+++ b/roles/agp_devspaces/templates/catalogsource.yaml.j2
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: "{{ install_operator_catalogsource_name }}"
+  namespace: "{{ install_operator_catalogsource_namespace }}"
+spec:
+  sourceType: grpc
+  image: "{{ install_operator_catalogsource_image }}:{{ install_operator_catalogsource_image_tag }}"
+  displayName: "{{ install_operator_catalogsource_name }}"
+  publisher: "Red Hat AgnosticD"
+{% if install_operator_catalogsource_pullsecrets | length > 0 %}
+  secrets: {{ install_operator_catalogsource_pullsecrets | to_json }}
+{% endif %}

--- a/roles/agp_devspaces/templates/installplan.yaml.j2
+++ b/roles/agp_devspaces/templates/installplan.yaml.j2
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: InstallPlan
+metadata:
+  name: "{{ install_operator_install_plan_name }}"
+  namespace: "{{ install_operator_namespace }}"
+spec:
+  approved: true

--- a/roles/agp_devspaces/templates/operatorgroup.yaml.j2
+++ b/roles/agp_devspaces/templates/operatorgroup.yaml.j2
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: "{{ install_operator_namespace }}-og"
+  namespace: "{{ install_operator_namespace }}"
+{% if install_operator_manage_namespaces is defined and install_operator_manage_namespaces | length > 0 %}
+spec:
+  targetNamespaces: {{ install_operator_manage_namespaces | to_json }}
+{% endif %}

--- a/roles/agp_devspaces/templates/subscription.yaml.j2
+++ b/roles/agp_devspaces/templates/subscription.yaml.j2
@@ -1,0 +1,23 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: "{{ install_operator_name }}"
+  namespace: "{{ install_operator_namespace }}"
+spec:
+  channel: "{{ __install_operator_channel }}"
+{% if install_operator_automatic_install_plan_approval | default(true) | bool %}
+  installPlanApproval: Automatic
+{% else %}
+  installPlanApproval: Manual
+{% endif %}
+  name: "{{ install_operator_packagemanifest_name }}"
+{% if install_operator_catalogsource_setup | default(false) | bool %}
+  source: "{{ install_operator_catalogsource_name }}"
+  sourceNamespace: "{{ install_operator_catalogsource_namespace }}"
+{% else %}
+  source: "{{ install_operator_catalog }}"
+  sourceNamespace: openshift-marketplace
+{% endif %}
+{% if install_operator_starting_csv | default("") | length > 0 %}
+  startingCSV: "{{ install_operator_starting_csv }}"
+{% endif %}

--- a/roles/agp_devspaces/tests/cleanup.yml
+++ b/roles/agp_devspaces/tests/cleanup.yml
@@ -15,16 +15,16 @@
           kind: DevWorkspace
           metadata:
             name: mydevworkspace
-            namespace: devworkspaces
+            namespace: "{{ agp_devspaces_namespace }}"
 
-    - name: Remove custom devworkspace namespace
-      kubernetes.core.k8s:
-        state: "{{ agp_devspaces_state }}"
-        definition:
-          apiVersion: v1
-          kind: Namespace
-          metadata:
-            name: devworkspaces
+    # - name: Remove custom devworkspace namespace
+    #   kubernetes.core.k8s:
+    #     state: "{{ agp_devspaces_state }}"
+    #     definition:
+    #       apiVersion: v1
+    #       kind: Namespace
+    #       metadata:
+    #         name: devworkspaces
 
     - name: Remove CheCluster
       kubernetes.core.k8s:
@@ -44,7 +44,7 @@
           kind: Subscription
           metadata:
             name: devspaces
-            namespace: openshift-devspaces
+            namespace: "{{ agp_devspaces_namespace }}"
 
     - name: Remove custom devspaces operator group
       kubernetes.core.k8s:
@@ -54,7 +54,7 @@
           kind: OperatorGroup
           metadata:
             name: openshift-devspaces-og
-            namespace: openshift-devspaces
+            namespace: "{{ agp_devspaces_namespace }}"
 
     - name: Remove DevSpaces namespace
       kubernetes.core.k8s:
@@ -63,7 +63,7 @@
           apiVersion: v1
           kind: Namespace
           metadata:
-            name: openshift-devspaces
+            name: "{{ agp_devspaces_namespace }}"
 
     - name: Remove mutatingwebhook
       kubernetes.core.k8s:

--- a/roles/agp_featuregate/defaults/main.yml
+++ b/roles/agp_featuregate/defaults/main.yml
@@ -1,0 +1,25 @@
+---
+agp_featuregate_become_override: false
+agp_featuregate_silent: false
+agp_featuregate_wait_for_cluster_operators: true
+agp_featuregate_pause_after_change_seconds: 10
+agp_featuregate_clusteroperator_wait_timeout: 30
+agp_featuregate_clusteroperator_wait_retries: 40
+agp_featuregate_enabled_features: []
+  # - ProcMountType
+  # - UserNamespacesSupport
+  # - UserNamespacesPodSecurityStandards
+
+# These operators will be excluded from the list of cluster operators to wait for
+agp_featuregate_skip_clusteroperator_wait_list: []
+  # - baremetal
+  # - cluster-autoscaler
+  # - image-registry
+  # - machine-config
+  # - marketplace
+  # - monitoring
+  # - network
+  # - openshift-samples
+  # - operator-lifecycle-manager
+  # - operator-lifecycle-manager-catalog
+  # - operator-lifecycle-manager-packageserver

--- a/roles/agp_featuregate/meta/argument_specs.yml
+++ b/roles/agp_featuregate/meta/argument_specs.yml
@@ -1,0 +1,11 @@
+---
+# argument spec file for jeffcpullen.agnosticp.agp_devspaces
+
+argument_specs:
+  main:
+    short_description: This role will enable OCP4 featuregates
+    # options:
+    #   my_variable:
+    #     type: str
+    #     description: A simple string argument for demonstration.
+    #     default: "default_value"

--- a/roles/agp_featuregate/meta/main.yml
+++ b/roles/agp_featuregate/meta/main.yml
@@ -1,0 +1,14 @@
+---
+galaxy_info:
+  role_name: agp_featuregate
+  author: Jeff Pullen
+  description: |
+    Enable OCP4 featuregates
+  license: MIT
+  min_ansible_version: "2.15"
+  platforms: []
+  galaxy_tags:
+    - openshift
+    - operators
+    - featuregate
+dependencies: []

--- a/roles/agp_featuregate/tasks/main.yml
+++ b/roles/agp_featuregate/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+# tasks file for jeffcpullen.agnosticp.agp_featuregate
+
+- name: Running Pre Workload Tasks
+  vars:
+    agp_featuregate_state: 'present'
+  ansible.builtin.include_tasks:
+    file: ./pre_workload.yml
+    apply:
+      become: "{{ agp_featuregate_become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  ansible.builtin.include_tasks:
+    file: ./workload.yml
+    apply:
+      become: "{{ agp_featuregate_become_override | bool }}"
+  vars:
+    agp_featuregate_state: 'present'
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  vars:
+    agp_featuregate_state: 'present'
+  ansible.builtin.include_tasks:
+    file: ./post_workload.yml
+    apply:
+      become: "{{ agp_featuregate_become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  vars:
+    agp_featuregate_state: 'absent'
+  ansible.builtin.include_tasks:
+    file: ./remove_workload.yml
+    apply:
+      become: "{{ agp_featuregate_become_override | bool }}"
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/roles/agp_featuregate/tasks/post_workload.yml
+++ b/roles/agp_featuregate/tasks/post_workload.yml
@@ -1,0 +1,73 @@
+---
+# Implement your Post Workload deployment tasks here
+# --------------------------------------------------
+
+- name: Role agp_featuregate | Task post_workload | Ensure featuregate is finished rolling out
+  when:
+    - agp_featuregate_wait_for_cluster_operators
+    - __agp_featuregate_patch_results.changed
+  block:
+
+    - name: Role agp_featuregate | Task post_workload | Pause for a few seconds to # noqa no-handler
+      ansible.builtin.pause:
+        seconds: "{{ agp_featuregate_pause_after_change_seconds }}"
+
+    - name: Role agp_featuregate | Task post_workload | Get cluster operators
+      kubernetes.core.k8s_info:
+        api_version: config.openshift.io/v1
+        kind: ClusterOperator
+      register: __cluster_operators
+
+    - name: Role agp_featuregate | Task post_workload | Initialize operator status list
+      ansible.builtin.set_fact:
+        __agp_featuregate_operator_status_list: []
+
+    - name: Role agp_featuregate | Task post_workload | Check operator status
+      ansible.builtin.set_fact:
+        __agp_featuregate_operator_status_list: >-
+          {{ __agp_featuregate_operator_status_list +
+            [ {'name': item.metadata.name }
+               ]
+          }}
+      loop: "{{ __cluster_operators.resources }}"
+
+    - name: Role agp_featuregate | Task post_workload | Get cluster operators with 'AsExpected' progressing reason
+      when: __cluster_operator_name.name not in agp_featuregate_skip_clusteroperator_wait_list
+      kubernetes.core.k8s_info:
+        api_version: config.openshift.io/v1
+        kind: ClusterOperator
+        name: "{{ __cluster_operator_name.name }}"
+        wait: true
+        wait_timeout: "{{ agp_featuregate_clusteroperator_wait_timeout }}"
+        wait_condition:
+          type: Progressing
+          status: false
+      register: __cluster_operators
+      retries: "{{ agp_featuregate_clusteroperator_wait_retries }}"
+      loop: "{{ __agp_featuregate_operator_status_list }}"
+      loop_control:
+        loop_var: __cluster_operator_name
+        label: "Waiting for cluster operator {{ __cluster_operator_name.name }} to finish roll-out"
+
+# Leave these as the last tasks in the playbook
+# ---------------------------------------------
+
+# For deployment onto a dedicated cluster (as part of the
+# cluster deployment) set workload_shared_deployment to False
+# This is the default so it does not have to be set explicitely
+- name: Role agp_featuregate | Task post_workload | post_workload tasks complete
+  ansible.builtin.debug:
+    msg: "Post-Workload tasks completed successfully."
+  when:
+    - not agp_featuregate_silent | bool
+    - not workload_shared_deployment | default(false) | bool
+
+# For RHPDS deployment (onto a shared cluster) set
+# workload_shared_deployment to True
+# (in the deploy script or AgnosticV configuration)
+- name: Role agp_featuregate | Task post_workload | post_workload tasks complete
+  ansible.builtin.debug:
+    msg: "Post-Software checks completed successfully"
+  when:
+    - not agp_featuregate_silent | bool
+    - workload_shared_deployment | default(false) | bool

--- a/roles/agp_featuregate/tasks/pre_workload.yml
+++ b/roles/agp_featuregate/tasks/pre_workload.yml
@@ -1,0 +1,27 @@
+---
+# Implement your Pre Workload deployment tasks here
+# -------------------------------------------------
+
+
+# Leave these as the last tasks in the playbook
+# ---------------------------------------------
+
+# For deployment onto a dedicated cluster (as part of the
+# cluster deployment) set workload_shared_deployment to False
+# This is the default so it does not have to be set explicitely
+- name: Role agp_featuregate | Task pre_workload | pre_workload tasks complete
+  ansible.builtin.debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when:
+    - not agp_featuregate_silent | bool
+    - not workload_shared_deployment | default(false) | bool
+
+# For RHPDS deployment (onto a shared cluster) set
+# workload_shared_deployment to True
+# (in the deploy script or AgnosticV configuration)
+- name: Role agp_featuregate | Task pre_workload | pre_workload tasks complete
+  ansible.builtin.debug:
+    msg: "Pre-Software checks completed successfully"
+  when:
+    - not agp_featuregate_silent | bool
+    - workload_shared_deployment | default(false) | bool

--- a/roles/agp_featuregate/tasks/remove_workload.yml
+++ b/roles/agp_featuregate/tasks/remove_workload.yml
@@ -1,0 +1,15 @@
+---
+# Implement your workload removal tasks here
+# ------------------------------------------
+
+
+# This playbook is called upon deletion of the environment
+# OpenShift resources get deleted automatically
+# Need to cleanup after ourselves in RHV though.
+
+# Leave this as the last task in the playbook.
+# --------------------------------------------
+- name: Role agp_featuregate | Task remove_workload | Remove_workload tasks complete
+  ansible.builtin.debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not agp_featuregate_silent | bool

--- a/roles/agp_featuregate/tasks/workload.yml
+++ b/roles/agp_featuregate/tasks/workload.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Role agp_featuregate | Task workload | Patch cluster featuregates
+  when:
+    - agp_featuregate_enabled_features is defined
+    # - agp_featuregate_enabled_features | length > 0
+  kubernetes.core.k8s:
+    state: patched
+    definition: "{{ lookup('template', 'featuregate_cluster.yaml.j2') | from_yaml }}"
+  register: __agp_featuregate_patch_results

--- a/roles/agp_featuregate/templates/featuregate_cluster.yaml.j2
+++ b/roles/agp_featuregate/templates/featuregate_cluster.yaml.j2
@@ -1,0 +1,9 @@
+---
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+spec:
+  featureSet: CustomNoUpgrade
+  customNoUpgrade:
+    enabled: {{ agp_featuregate_enabled_features }}


### PR DESCRIPTION
The agp_devspaces role doesn't need to have the featuregate enabling capabilities. That needed to be split into its own role which this PR does. It was also brittle and prone to failures because it wasn't capable of monitoring the deployment of the operator. This adds the ability to monitor progress of operator deployments.