### PR TITLE
fix: add a rescue to the cluster operator check and extend wait times

### DIFF
--- a/roles/agp_featuregate/defaults/main.yml
+++ b/roles/agp_featuregate/defaults/main.yml
@@ -2,9 +2,12 @@
 agp_featuregate_become_override: false
 agp_featuregate_silent: false
 agp_featuregate_wait_for_cluster_operators: true
-agp_featuregate_pause_after_change_seconds: 10
-agp_featuregate_clusteroperator_wait_timeout: 30
+agp_featuregate_pause_after_change_seconds: 30
+agp_featuregate_clusteroperator_wait_timeout: 60
 agp_featuregate_clusteroperator_wait_retries: 40
+agp_featuregate_fail_on_co_check: false
+agp_featuregate_clusteroperator_proceed_after_co_fail_wait_seconds: 300
+
 agp_featuregate_enabled_features: []
   # - ProcMountType
   # - UserNamespacesSupport

--- a/roles/agp_featuregate/tasks/post_workload.yml
+++ b/roles/agp_featuregate/tasks/post_workload.yml
@@ -49,6 +49,21 @@
         loop_var: __cluster_operator_name
         label: "Waiting for cluster operator {{ __cluster_operator_name.name }} to finish roll-out"
 
+  rescue:
+
+    - name: Role agp_featuregate | Task post_workload | Fail playbook if operator check does not succeed
+      when: agp_featuregate_fail_on_co_check
+      ansible.builtin.fail:
+        msg: >-
+          Cluster operator check did not succeed.
+          If you do not want to cause this check to fail the role
+          rerun with agp_featuregate_fail_on_co_check set to false
+
+    - name: Role agp_featuregate | Task post_workload | Pause to allow cluster operators to settle.
+      when: not agp_featuregate_fail_on_co_check
+      ansible.builtin.pause:
+        seconds: "{{ agp_featuregate_clusteroperator_proceed_after_co_fail_wait_seconds }}"
+
 # Leave these as the last tasks in the playbook
 # ---------------------------------------------
 


### PR DESCRIPTION
If the api takes more than 30 seconds to respond to the health of the cluster operators it would cause the role to fail. The featuregate role expects the API to have issues which is why it is checking. This adds some buffer to minimize the unexpected failures.